### PR TITLE
feat: Implement Welcome Screen and new startup flow

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,58 @@
 import sys
 from PySide6.QtWidgets import QApplication
-from main_window import MainWindow
+from PySide6.QtCore import QObject, Slot # QObject and Slot for launch_main_window
+from welcome_screen import WelcomeScreen # Assuming welcome_screen.py is in the same directory
+from main_window import MainWindow     # Assuming main_window.py is in the same directory
+
+class AppController(QObject):
+    def __init__(self):
+        super().__init__() # Initialize QObject
+        # QApplication must be created before any QWidgets
+        # It's common to create it once here.
+        if QApplication.instance():
+            self.app = QApplication.instance()
+        else:
+            self.app = QApplication(sys.argv)
+
+        self.welcome_screen = WelcomeScreen()
+        # MainWindow will be created when a path is selected,
+        # or if needed for a "no path" scenario (though current flow avoids this).
+        self.main_window = None
+
+        # Connect the signal from WelcomeScreen to a slot in AppController
+        self.welcome_screen.path_selected.connect(self.launch_main_window)
+
+    def run(self):
+        self.welcome_screen.show()
+        sys.exit(self.app.exec()) # Start the application event loop
+
+    @Slot(str) # Decorate as a slot
+    def launch_main_window(self, path: str):
+        if path: # Ensure path is not empty
+            # Create or re-initialize MainWindow instance here
+            if self.main_window is None:
+                self.main_window = MainWindow(initial_path=path)
+            else:
+                # If main_window instance already exists (e.g., if user could go back to welcome screen)
+                # we should re-initialize it with the new path.
+                # This assumes MainWindow can handle being re-initialized or has a method like initialize_project
+                self.main_window.initialize_project(path) # Ensure this method exists and works as expected
+
+            self.main_window.show()
+            self.welcome_screen.close() # Close the welcome screen
+        else:
+            # Handle case where path might be empty, though WelcomeScreen should prevent this
+            print("LOG: No valid path received from welcome screen. Re-showing welcome screen.")
+            # If path is empty, it implies an issue or a desire to go back/stay on welcome.
+            # For robustness, ensure welcome screen is visible if main window isn't shown.
+            if not (self.main_window and self.main_window.isVisible()):
+                 self.welcome_screen.show()
+
 
 if __name__ == "__main__":
-    app = QApplication(sys.argv)
-    window = MainWindow()
-    window.show()
-    sys.exit(app.exec())
+    # Ensure PySide6 is correctly initialized for fonts, styles etc.
+    # QApplication.setAttribute(Qt.AA_EnableHighDpiScaling) # Optional, for HiDPI
+    # QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps)  # Optional, for HiDPI
+
+    controller = AppController()
+    controller.run()

--- a/welcome_screen.py
+++ b/welcome_screen.py
@@ -1,0 +1,95 @@
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QPushButton, QFileDialog, QHBoxLayout, QListWidget
+from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtGui import QFont
+
+class WelcomeScreen(QWidget):
+    # Signal to emit the selected path (file or folder)
+    path_selected = Signal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Welcome - Aether Editor")
+        self.setFixedSize(500, 350) # Give it a decent fixed size
+
+        main_layout = QVBoxLayout(self)
+        main_layout.setAlignment(Qt.AlignCenter)
+        main_layout.setSpacing(20)
+
+        # Title Label
+        title_label = QLabel("Welcome to Aether Editor")
+        title_font = QFont()
+        title_font.setPointSize(20)
+        title_font.setBold(True)
+        title_label.setFont(title_font)
+        title_label.setAlignment(Qt.AlignCenter)
+        main_layout.addWidget(title_label)
+
+        # Buttons Layout
+        buttons_layout = QHBoxLayout()
+        buttons_layout.setSpacing(15)
+
+        # Open Folder Button
+        self.open_folder_button = QPushButton("Open Folder...")
+        self.open_folder_button.setMinimumHeight(40) # Make buttons a bit taller
+        font = self.open_folder_button.font()
+        font.setPointSize(10)
+        self.open_folder_button.setFont(font)
+        buttons_layout.addWidget(self.open_folder_button)
+
+        # Open File Button
+        self.open_file_button = QPushButton("Open File...")
+        self.open_file_button.setMinimumHeight(40)
+        self.open_file_button.setFont(font) # Use the same font size
+        buttons_layout.addWidget(self.open_file_button)
+
+        main_layout.addLayout(buttons_layout)
+
+        # Placeholder for Recent Projects (Optional)
+        recent_projects_label = QLabel("Recent Projects (Placeholder):")
+        recent_projects_label.setAlignment(Qt.AlignCenter)
+        # main_layout.addWidget(recent_projects_label) # Uncomment if you want the label
+
+        self.recent_projects_list = QListWidget()
+        self.recent_projects_list.setEnabled(False) # Disabled for now as it's a placeholder
+        # main_layout.addWidget(self.recent_projects_list) # Uncomment if you want the list widget visible
+
+        # Connect signals
+        self.open_folder_button.clicked.connect(self._open_folder_dialog)
+        self.open_file_button.clicked.connect(self._open_file_dialog)
+
+    @Slot()
+    def _open_folder_dialog(self):
+        folder_path = QFileDialog.getExistingDirectory(
+            self,
+            "Open Folder",
+            "", # Start directory (can be QStandardPaths.HomeLocation)
+            QFileDialog.ShowDirsOnly
+        )
+        if folder_path:
+            self.path_selected.emit(folder_path)
+
+    @Slot()
+    def _open_file_dialog(self):
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Open File",
+            "", # Start directory
+            "All Files (*.*);;Python Files (*.py);;Text Files (*.txt)" # Filter
+        )
+        if file_path:
+            self.path_selected.emit(file_path)
+
+if __name__ == '__main__':
+    # Example usage for testing the WelcomeScreen independently
+    import sys
+    from PySide6.QtWidgets import QApplication
+    app = QApplication(sys.argv)
+    welcome_screen = WelcomeScreen()
+    welcome_screen.show()
+
+    def handle_path(path):
+        print(f"Path selected: {path}")
+        # welcome_screen.close() # Optionally close after selection for testing
+
+    welcome_screen.path_selected.connect(handle_path)
+    sys.exit(app.exec())


### PR DESCRIPTION
This commit introduces a new application startup flow featuring a Welcome Screen. Instead of automatically loading the last session or a default project, you are now prompted to open an existing folder or file before the main IDE window is launched.

Key architectural changes:

1.  **`welcome_screen.py` (New File):**
    -   Defines `WelcomeScreen(QWidget)` which provides UI options to
        "Open Folder..." or "Open File...".
    -   Emits a `path_selected(str)` signal with your choice.

2.  **`main_window.py` (Refactored):**
    -   `__init__` now accepts an optional `initial_path` argument.
    -   A new `initialize_project(self, path: str)` method centralizes
        the logic for setting the file explorer root, starting the
        terminal in the correct directory, and opening a file if `path`
        points to one. It also handles closing an initial "Untitled" tab
        if a specific project/file is being opened.
    -   All previous session persistence code (`load_session`,
        `save_session`, `_get_session_file_path`, and related calls in
        `__init__` and `closeEvent`) has been removed, as this new
        startup flow supersedes it.

3.  **`main.py` (Rewritten):**
    -   Introduces `AppController(QObject)` to manage the application
        lifecycle.
    -   The controller first displays the `WelcomeScreen`.
    -   Upon receiving the `path_selected` signal from the welcome screen,
        the controller calls `main_window.initialize_project(path)` with
        the chosen path, then shows the main IDE window and closes the
        welcome screen.
    -   `MainWindow` is now instantiated by the `AppController` only
        when a path is selected.

This change provides a more explicit and user-driven project/file selection process at startup.